### PR TITLE
Add log4php to phive

### DIFF
--- a/data/repositories.xml
+++ b/data/repositories.xml
@@ -96,4 +96,7 @@
     <phar alias="deptrac" composer="sensiolabs-de/deptrac">
         <repository type="github" url="https://api.github.com/repos/sensiolabs-de/deptrac/releases" />
     </phar>
+    <phar alias="log4php" composer="apache/log4php">
+        <repository type="github" url="https://api.github.com/repos/apache/logging-log4php/releases" />
+    </phar>
 </repositories>


### PR DESCRIPTION
I'm doing some cleanup work on log4php, and am working on adding phar distribution.